### PR TITLE
Mention bitwarden in boarding.md

### DIFF
--- a/boarding.md
+++ b/boarding.md
@@ -9,6 +9,8 @@
 - GitHub
   - Add to [Moderation team](https://github.com/orgs/NixOS/teams/moderation)
   - Update [team page on homepage](https://github.com/NixOS/nixos-homepage/blob/master/community/teams/moderation.tt)
+- Bitwarden
+  - Invite into the Moderation Team organization (via Infrastructure team)
 
 ## Offboarding
 - Matrix
@@ -20,3 +22,6 @@
 - GitHub
   - Remove from [Moderation team](https://github.com/orgs/NixOS/teams/moderation)
   - Update [team page on homepage](https://github.com/NixOS/nixos-homepage/blob/master/community/teams/moderation.tt)
+- Bitwarden
+  - Remove from Moderation Team organization (via Infrastructure team)
+  - Rotate secrets


### PR DESCRIPTION
Bitwarden holds for example the secrets for the @admin:nixos.org account, that we use to manage the space.

I think we rely on the foundation/infra to synchronize the members for us.