### PR TITLE
Update boarding.md to set up Discourse password and 2FA *first*

### DIFF
--- a/boarding.md
+++ b/boarding.md
@@ -4,6 +4,7 @@
   - [ ] Add to private discussion room
   - [ ] Add to mjolnir admin room
 - Discourse
+  - [ ] Set a password in Discourse (if you have bene using OIDC federation until now), and enable 2FA  
   - [ ] Set to Moderator
   - [ ] Add to Moderation Team
   - [ ] Announce team membership update


### PR DESCRIPTION
Note that Discourse UX flow is *terrible* if you get added as a moderator without 2FA already set up. It effectively blocks your account insisting you enable 2FA to continue (which is probably reasonable), but you have to "enter your existing password to continue" as the first step of this.

If you have been using OIDC federation ("login with github") until now, there is no local password to enter.  So the only option is a password reset email, which effectively falls back to a weaker security mechanism in order to try and bootstrap a stronger one.

So, let's add that as an explicit step in advance