### PR TITLE
 Clarify use of Matrix room.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The moderation team is not anonymous, you can always look up its current members
 ## Reporting issues
 
 - E-mail: [moderation@nixos.org](mailto:moderation@nixos.org).
-- Matrix room: [#moderation:nixos.org](https://matrix.to/#/#moderation:nixos.org)
+- Matrix room (please only use for urgent issues!): [#moderation:nixos.org](https://matrix.to/#/#moderation:nixos.org)
 - On Discourse: [moderators group](https://discourse.nixos.org/g/moderators)
 - On GitHub, ping [`@NixOS/moderation`](https://nixos.org/community/teams/moderation)
 


### PR DESCRIPTION
Neither the README nor the Matrix channel info mentions that the Matrix is only for urgent issues:

![image](https://github.com/user-attachments/assets/55363be7-3269-42ca-8e02-c5fcced260a1)

The matrix is supposed to be used only for [urgent issues](https://matrix.to/#/!uzGGsQXWXsuwIqJImY:nixos.org/$LEONxyl2RJqPac6Naf8pdrspU2e93VjAIW86rZlkBTs?via=nixos.org&via=matrix.org&via=nixos.dev):

![image](https://github.com/user-attachments/assets/1d1aa3d2-7e2f-4487-a529-41d08f02ad36)

This PR updates the public policy documentation to match the position of the mod team.